### PR TITLE
Disable vector icons PNG rasterisation

### DIFF
--- a/compound/build.gradle.kts
+++ b/compound/build.gradle.kts
@@ -29,6 +29,11 @@ android {
     defaultConfig {
         compileSdk = 34
         minSdk = 23
+
+        vectorDrawables {
+            useSupportLibrary = true
+            generatedDensities()
+        }
     }
 
     compileOptions {


### PR DESCRIPTION
This was causing crashes on API 23 when vector images were being loaded using `ImageVector.vectorResource(resId)`.