### PR TITLE
Simplify and expose colors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,11 +48,8 @@ jobs:
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
-      - name: ⚙️ Run unit tests
+      - name: ⚙️ Run unit tests and screenshot tests
         run: ./gradlew testDebugUnitTest $CI_GRADLE_ARG_PROPERTIES
-
-      - name: 📸 Run screenshot tests
-        run: ./gradlew :compound:verifyRoborazziDebug $CI_GRADLE_ARG_PROPERTIES
 
       - name: 📈Generate kover report and verify coverage
         run: ./gradlew :compound:koverHtmlReport :compound:koverXmlReport :compound:koverVerify $CI_GRADLE_ARG_PROPERTIES -Pci-build=true

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ captures/
 .idea/modules.xml
 # Comment next line if keeping position of elements in Navigation Editor is relevant for you
 .idea/navEditor.xml
+.idea/other.xml
 .idea/tasks.xml
 .idea/workspace.xml
 .idea/libraries

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ All tokens can be accessed through the `ElementTheme` object, which contains the
 
 All new tokens **should** come from Compound and added to the `compound.generated` package. To map the literal tokens to the semantic ones, you'll have to update both `compoundColorsLight` and `compoundColorsDark` in `CompoundColors.kt`.
 
+## Unit tests
+
+To run Roborazzi test, run:
+
+```bash
+./gradlew :compound:verifyRoborazziDebug
+```
+
+To record the screenshot, run:
+
+```bash
+./gradlew :compound:recordRoborazziDebug
+```
+
 ## Releasing
 
 To release a new version of the module, you'll have to:

--- a/compound/src/main/kotlin/io/element/android/compound/theme/ElementTheme.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/ElementTheme.kt
@@ -113,8 +113,8 @@ fun ElementTheme(
     dynamicColor: Boolean = false, /* true to enable MaterialYou */
     compoundLight: SemanticColors = compoundColorsLight,
     compoundDark: SemanticColors = compoundColorsDark,
-    materialColorsLight: ColorScheme = compoundColorsLight.toMaterialColorScheme(),
-    materialColorsDark: ColorScheme = compoundColorsDark.toMaterialColorScheme(),
+    materialColorsLight: ColorScheme = compoundLight.toMaterialColorScheme(),
+    materialColorsDark: ColorScheme = compoundDark.toMaterialColorScheme(),
     typography: Typography = compoundTypography,
     content: @Composable () -> Unit,
 ) {

--- a/compound/src/main/kotlin/io/element/android/compound/theme/ElementTheme.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/ElementTheme.kt
@@ -114,10 +114,6 @@ fun ElementTheme(
     typography: Typography = compoundTypography,
     content: @Composable () -> Unit,
 ) {
-    val currentCompoundColor = remember(darkTheme) {
-        compoundColors.copy()
-    }.apply { updateColorsFrom(compoundColors) }
-
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
@@ -157,7 +153,7 @@ fun ElementTheme(
         }
     }
     CompositionLocalProvider(
-        LocalCompoundColors provides currentCompoundColor,
+        LocalCompoundColors provides compoundColors,
         LocalContentColor provides colorScheme.onSurface,
     ) {
         MaterialTheme(

--- a/compound/src/main/kotlin/io/element/android/compound/theme/ElementTheme.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/ElementTheme.kt
@@ -98,8 +98,10 @@ internal val LocalCompoundColors = staticCompositionLocalOf { compoundColorsLigh
  * This is specially useful when you want to apply an alternate theme to a part of the app but don't want it to affect the system bars.
  * @param lightStatusBar whether to use a light status bar color scheme or not. By default, it's the opposite of [darkTheme].
  * @param dynamicColor whether to enable MaterialYou or not. It's `false` by default.
- * @param compoundColors the [SemanticColors] to use. By default it'll automatically use the light or dark theme colors based on the system theme.
- * @param materialColors the Material 3 [ColorScheme] to use. It'll use either [materialColorSchemeLight] or [materialColorSchemeDark] by default.
+ * @param compoundLight the [SemanticColors] to use in light theme.
+ * @param compoundDark the [SemanticColors] to use in dark theme.
+ * @param materialColorsLight the Material 3 [ColorScheme] to use in light theme.
+ * @param materialColorsDark the Material 3 [ColorScheme] to use in dark theme.
  * @param typography the Material 3 [Typography] tokens to use. It'll use [compoundTypography] by default.
  * @param content the content to apply the theme to.
  */
@@ -109,17 +111,24 @@ fun ElementTheme(
     applySystemBarsUpdate: Boolean = true,
     lightStatusBar: Boolean = !darkTheme,
     dynamicColor: Boolean = false, /* true to enable MaterialYou */
-    compoundColors: SemanticColors = if (darkTheme) compoundColorsDark else compoundColorsLight,
-    materialColors: ColorScheme = if (darkTheme) materialColorSchemeDark else materialColorSchemeLight,
+    compoundLight: SemanticColors = compoundColorsLight,
+    compoundDark: SemanticColors = compoundColorsDark,
+    materialColorsLight: ColorScheme = compoundColorsLight.toMaterialColorScheme(),
+    materialColorsDark: ColorScheme = compoundColorsDark.toMaterialColorScheme(),
     typography: Typography = compoundTypography,
     content: @Composable () -> Unit,
 ) {
+    val currentCompoundColor = remember(darkTheme) {
+        if (darkTheme) compoundDark else compoundLight
+    }
+
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
-        else -> materialColors
+        darkTheme -> materialColorsDark
+        else -> materialColorsLight
     }
 
     val statusBarColorScheme = if (dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -153,7 +162,7 @@ fun ElementTheme(
         }
     }
     CompositionLocalProvider(
-        LocalCompoundColors provides compoundColors,
+        LocalCompoundColors provides currentCompoundColor,
         LocalContentColor provides colorScheme.onSurface,
     ) {
         MaterialTheme(

--- a/compound/src/main/kotlin/io/element/android/compound/theme/ElementTheme.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/ElementTheme.kt
@@ -118,8 +118,9 @@ fun ElementTheme(
     typography: Typography = compoundTypography,
     content: @Composable () -> Unit,
 ) {
-    val currentCompoundColor = remember(darkTheme) {
-        if (darkTheme) compoundDark else compoundLight
+    val currentCompoundColor = when {
+        darkTheme -> compoundDark
+        else -> compoundLight
     }
 
     val colorScheme = when {

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
@@ -97,7 +97,7 @@ fun SemanticColors.toMaterialColorScheme(): ColorScheme {
     }
 }
 
-@Preview
+@Preview(heightDp = 1200)
 @Composable
 internal fun ColorsSchemeLightPreview() = ElementTheme {
     ColorsSchemePreview(
@@ -107,7 +107,7 @@ internal fun ColorsSchemeLightPreview() = ElementTheme {
     )
 }
 
-@Preview
+@Preview(heightDp = 1200)
 @Composable
 internal fun ColorsSchemeDarkPreview() = ElementTheme(darkTheme = true) {
     ColorsSchemePreview(

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
@@ -27,7 +27,7 @@ import io.element.android.compound.tokens.generated.internal.DarkColorTokens
 import io.element.android.compound.tokens.generated.internal.LightColorTokens
 
 @OptIn(CoreColorToken::class)
-internal val materialColorSchemeLight = lightColorScheme(
+val materialColorSchemeLight = lightColorScheme(
     primary = LightColorTokens.colorGray1400,
     onPrimary = LightColorTokens.colorThemeBg,
     primaryContainer = LightColorTokens.colorThemeBg,
@@ -60,7 +60,7 @@ internal val materialColorSchemeLight = lightColorScheme(
 )
 
 @OptIn(CoreColorToken::class)
-internal val materialColorSchemeDark = darkColorScheme(
+val materialColorSchemeDark = darkColorScheme(
     primary = DarkColorTokens.colorGray1400,
     onPrimary = DarkColorTokens.colorThemeBg,
     primaryContainer = DarkColorTokens.colorThemeBg,

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
@@ -24,15 +24,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import io.element.android.compound.annotations.CoreColorToken
 import io.element.android.compound.previews.ColorsSchemePreview
-import io.element.android.compound.tokens.compoundColorsDark
-import io.element.android.compound.tokens.compoundColorsLight
 import io.element.android.compound.tokens.generated.SemanticColors
 import io.element.android.compound.tokens.generated.internal.DarkColorTokens
 import io.element.android.compound.tokens.generated.internal.LightColorTokens
-
-val materialColorSchemeLight = compoundColorsLight.toMaterialColorScheme()
-
-val materialColorSchemeDark = compoundColorsDark.toMaterialColorScheme()
 
 @OptIn(CoreColorToken::class)
 fun SemanticColors.toMaterialColorScheme(): ColorScheme {
@@ -119,6 +113,6 @@ internal fun ColorsSchemeDarkPreview() = ElementTheme(darkTheme = true) {
     ColorsSchemePreview(
         Color.White,
         Color.Black,
-        materialColorSchemeDark,
+        ElementTheme.materialColors,
     )
 }

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
@@ -16,6 +16,7 @@
 
 package io.element.android.compound.theme
 
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -23,74 +24,84 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import io.element.android.compound.annotations.CoreColorToken
 import io.element.android.compound.previews.ColorsSchemePreview
+import io.element.android.compound.tokens.compoundColorsDark
+import io.element.android.compound.tokens.compoundColorsLight
+import io.element.android.compound.tokens.generated.SemanticColors
 import io.element.android.compound.tokens.generated.internal.DarkColorTokens
 import io.element.android.compound.tokens.generated.internal.LightColorTokens
 
-@OptIn(CoreColorToken::class)
-val materialColorSchemeLight = lightColorScheme(
-    primary = LightColorTokens.colorGray1400,
-    onPrimary = LightColorTokens.colorThemeBg,
-    primaryContainer = LightColorTokens.colorThemeBg,
-    onPrimaryContainer = LightColorTokens.colorGray1400,
-    inversePrimary = LightColorTokens.colorThemeBg,
-    secondary = LightColorTokens.colorGray900,
-    onSecondary = LightColorTokens.colorThemeBg,
-    secondaryContainer = LightColorTokens.colorGray400,
-    onSecondaryContainer = LightColorTokens.colorGray1400,
-    tertiary = LightColorTokens.colorGray900,
-    onTertiary = LightColorTokens.colorThemeBg,
-    tertiaryContainer = LightColorTokens.colorGray1400,
-    onTertiaryContainer = LightColorTokens.colorThemeBg,
-    background = LightColorTokens.colorThemeBg,
-    onBackground = LightColorTokens.colorGray1400,
-    surface = LightColorTokens.colorThemeBg,
-    onSurface = LightColorTokens.colorGray1400,
-    surfaceVariant = LightColorTokens.colorGray300,
-    onSurfaceVariant = LightColorTokens.colorGray900,
-    surfaceTint = LightColorTokens.colorGray1000,
-    inverseSurface = LightColorTokens.colorGray1300,
-    inverseOnSurface = LightColorTokens.colorThemeBg,
-    error = LightColorTokens.colorRed900,
-    onError = LightColorTokens.colorThemeBg,
-    errorContainer = LightColorTokens.colorRed400,
-    onErrorContainer = LightColorTokens.colorRed900,
-    outline = LightColorTokens.colorGray800,
-    outlineVariant = LightColorTokens.colorAlphaGray400,
-    scrim = LightColorTokens.colorGray1400,
-)
+val materialColorSchemeLight = compoundColorsLight.toMaterialColorScheme()
+
+val materialColorSchemeDark = compoundColorsDark.toMaterialColorScheme()
 
 @OptIn(CoreColorToken::class)
-val materialColorSchemeDark = darkColorScheme(
-    primary = DarkColorTokens.colorGray1400,
-    onPrimary = DarkColorTokens.colorThemeBg,
-    primaryContainer = DarkColorTokens.colorThemeBg,
-    onPrimaryContainer = DarkColorTokens.colorGray1400,
-    inversePrimary = DarkColorTokens.colorThemeBg,
-    secondary = DarkColorTokens.colorGray900,
-    onSecondary = DarkColorTokens.colorThemeBg,
-    secondaryContainer = DarkColorTokens.colorGray400,
-    onSecondaryContainer = DarkColorTokens.colorGray1400,
-    tertiary = DarkColorTokens.colorGray900,
-    onTertiary = DarkColorTokens.colorThemeBg,
-    tertiaryContainer = DarkColorTokens.colorGray1400,
-    onTertiaryContainer = DarkColorTokens.colorThemeBg,
-    background = DarkColorTokens.colorThemeBg,
-    onBackground = DarkColorTokens.colorGray1400,
-    surface = DarkColorTokens.colorThemeBg,
-    onSurface = DarkColorTokens.colorGray1400,
-    surfaceVariant = DarkColorTokens.colorGray300,
-    onSurfaceVariant = DarkColorTokens.colorGray900,
-    surfaceTint = DarkColorTokens.colorGray1000,
-    inverseSurface = DarkColorTokens.colorGray1300,
-    inverseOnSurface = DarkColorTokens.colorThemeBg,
-    error = DarkColorTokens.colorRed900,
-    onError = DarkColorTokens.colorThemeBg,
-    errorContainer = DarkColorTokens.colorRed400,
-    onErrorContainer = DarkColorTokens.colorRed900,
-    outline = DarkColorTokens.colorGray800,
-    outlineVariant = DarkColorTokens.colorAlphaGray400,
-    scrim = DarkColorTokens.colorGray300,
-)
+fun SemanticColors.toMaterialColorScheme(): ColorScheme {
+    return if (isLight) {
+        lightColorScheme(
+            primary = textPrimary,
+            onPrimary = textOnSolidPrimary,
+            primaryContainer = textOnSolidPrimary,
+            onPrimaryContainer = textPrimary,
+            inversePrimary = textOnSolidPrimary,
+            secondary = textSecondary,
+            onSecondary = textOnSolidPrimary,
+            secondaryContainer = bgSubtlePrimary,
+            onSecondaryContainer = textPrimary,
+            tertiary = textSecondary,
+            onTertiary = textOnSolidPrimary,
+            tertiaryContainer = textPrimary,
+            onTertiaryContainer = textOnSolidPrimary,
+            background = textOnSolidPrimary,
+            onBackground = textPrimary,
+            surface = textOnSolidPrimary,
+            onSurface = textPrimary,
+            surfaceVariant = LightColorTokens.colorGray300,
+            onSurfaceVariant = textSecondary,
+            surfaceTint = LightColorTokens.colorGray1000,
+            inverseSurface = LightColorTokens.colorGray1300,
+            inverseOnSurface = textOnSolidPrimary,
+            error = bgCriticalPrimary,
+            onError = textOnSolidPrimary,
+            errorContainer = LightColorTokens.colorRed400,
+            onErrorContainer = textCriticalPrimary,
+            outline = textPlaceholder,
+            outlineVariant = LightColorTokens.colorAlphaGray400,
+            scrim = textPrimary,
+        )
+    } else {
+        darkColorScheme(
+            primary = textPrimary,
+            onPrimary = textOnSolidPrimary,
+            primaryContainer = textOnSolidPrimary,
+            onPrimaryContainer = textPrimary,
+            inversePrimary = textOnSolidPrimary,
+            secondary = textSecondary,
+            onSecondary = textOnSolidPrimary,
+            secondaryContainer = bgSubtlePrimary,
+            onSecondaryContainer = textPrimary,
+            tertiary = textSecondary,
+            onTertiary = textOnSolidPrimary,
+            tertiaryContainer = textPrimary,
+            onTertiaryContainer = textOnSolidPrimary,
+            background = textOnSolidPrimary,
+            onBackground = textPrimary,
+            surface = textOnSolidPrimary,
+            onSurface = textPrimary,
+            surfaceVariant = DarkColorTokens.colorGray300,
+            onSurfaceVariant = textSecondary,
+            surfaceTint = DarkColorTokens.colorGray1000,
+            inverseSurface = DarkColorTokens.colorGray1300,
+            inverseOnSurface = textOnSolidPrimary,
+            error = bgCriticalPrimary,
+            onError = textOnSolidPrimary,
+            errorContainer = DarkColorTokens.colorRed400,
+            onErrorContainer = textCriticalPrimary,
+            outline = textPlaceholder,
+            outlineVariant = DarkColorTokens.colorAlphaGray400,
+            scrim = bgSubtleSecondary,
+        )
+    }
+}
 
 @Preview
 @Composable

--- a/compound/src/main/kotlin/io/element/android/compound/tokens/CompoundColors.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/tokens/CompoundColors.kt
@@ -22,7 +22,7 @@ import io.element.android.compound.tokens.generated.internal.DarkColorTokens
 import io.element.android.compound.tokens.generated.internal.LightColorTokens
 
 @OptIn(CoreColorToken::class)
-internal val compoundColorsLight = SemanticColors(
+val compoundColorsLight = SemanticColors(
     textPrimary = LightColorTokens.colorGray1400,
     textSecondary = LightColorTokens.colorGray900,
     textPlaceholder = LightColorTokens.colorGray800,
@@ -94,7 +94,7 @@ internal val compoundColorsLight = SemanticColors(
 )
 
 @OptIn(CoreColorToken::class)
-internal val compoundColorsDark = SemanticColors(
+val compoundColorsDark = SemanticColors(
     textPrimary = DarkColorTokens.colorGray1400,
     textSecondary = DarkColorTokens.colorGray900,
     textPlaceholder = DarkColorTokens.colorGray800,

--- a/compound/src/main/kotlin/io/element/android/compound/tokens/generated/SemanticColors.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/tokens/generated/SemanticColors.kt
@@ -18,11 +18,13 @@
 
 package io.element.android.compound.tokens.generated
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 
 /**
  * This class holds all the semantic tokens of the Compound theme.
  */
+@Immutable
 data class SemanticColors(
     /** Background colour for accent or brand actions. State: Hover */
     val bgAccentHovered: Color,

--- a/compound/src/main/kotlin/io/element/android/compound/tokens/generated/SemanticColors.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/tokens/generated/SemanticColors.kt
@@ -15,507 +15,149 @@
  */
 
 @file:Suppress("all")
+
 package io.element.android.compound.tokens.generated
 
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
 
-
-
-
-
 /**
-  * This class holds all the semantic tokens of the Compound theme.
-  */
-@Stable
-class SemanticColors(
-    bgAccentHovered: Color,
-    bgAccentPressed: Color,
-    bgAccentRest: Color,
-    bgActionPrimaryDisabled: Color,
-    bgActionPrimaryHovered: Color,
-    bgActionPrimaryPressed: Color,
-    bgActionPrimaryRest: Color,
-    bgActionSecondaryHovered: Color,
-    bgActionSecondaryPressed: Color,
-    bgActionSecondaryRest: Color,
-    bgCanvasDefault: Color,
-    bgCanvasDisabled: Color,
-    bgCriticalHovered: Color,
-    bgCriticalPrimary: Color,
-    bgCriticalSubtle: Color,
-    bgCriticalSubtleHovered: Color,
-    bgDecorative1: Color,
-    bgDecorative2: Color,
-    bgDecorative3: Color,
-    bgDecorative4: Color,
-    bgDecorative5: Color,
-    bgDecorative6: Color,
-    bgInfoSubtle: Color,
-    bgSubtlePrimary: Color,
-    bgSubtleSecondary: Color,
-    bgSuccessSubtle: Color,
-    borderCriticalHovered: Color,
-    borderCriticalPrimary: Color,
-    borderCriticalSubtle: Color,
-    borderDisabled: Color,
-    borderFocused: Color,
-    borderInfoSubtle: Color,
-    borderInteractiveHovered: Color,
-    borderInteractivePrimary: Color,
-    borderInteractiveSecondary: Color,
-    borderSuccessSubtle: Color,
-    iconAccentTertiary: Color,
-    iconCriticalPrimary: Color,
-    iconDisabled: Color,
-    iconInfoPrimary: Color,
-    iconOnSolidPrimary: Color,
-    iconPrimary: Color,
-    iconPrimaryAlpha: Color,
-    iconQuaternary: Color,
-    iconQuaternaryAlpha: Color,
-    iconSecondary: Color,
-    iconSecondaryAlpha: Color,
-    iconSuccessPrimary: Color,
-    iconTertiary: Color,
-    iconTertiaryAlpha: Color,
-    textActionAccent: Color,
-    textActionPrimary: Color,
-    textCriticalPrimary: Color,
-    textDecorative1: Color,
-    textDecorative2: Color,
-    textDecorative3: Color,
-    textDecorative4: Color,
-    textDecorative5: Color,
-    textDecorative6: Color,
-    textDisabled: Color,
-    textInfoPrimary: Color,
-    textLinkExternal: Color,
-    textOnSolidPrimary: Color,
-    textPlaceholder: Color,
-    textPrimary: Color,
-    textSecondary: Color,
-    textSuccessPrimary: Color,
-    isLight: Boolean,
-) {
-    var isLight by mutableStateOf(isLight)
-        private set
+ * This class holds all the semantic tokens of the Compound theme.
+ */
+data class SemanticColors(
     /** Background colour for accent or brand actions. State: Hover */
-    var bgAccentHovered by mutableStateOf(bgAccentHovered)
-        private set
+    val bgAccentHovered: Color,
     /** Background colour for accent or brand actions. State: Pressed */
-    var bgAccentPressed by mutableStateOf(bgAccentPressed)
-        private set
+    val bgAccentPressed: Color,
     /** Background colour for accent or brand actions. State: Rest. */
-    var bgAccentRest by mutableStateOf(bgAccentRest)
-        private set
+    val bgAccentRest: Color,
     /** Background colour for primary actions. State: Disabled. */
-    var bgActionPrimaryDisabled by mutableStateOf(bgActionPrimaryDisabled)
-        private set
+    val bgActionPrimaryDisabled: Color,
     /** Background colour for primary actions. State: Hover. */
-    var bgActionPrimaryHovered by mutableStateOf(bgActionPrimaryHovered)
-        private set
+    val bgActionPrimaryHovered: Color,
     /** Background colour for primary actions. State: Pressed. */
-    var bgActionPrimaryPressed by mutableStateOf(bgActionPrimaryPressed)
-        private set
+    val bgActionPrimaryPressed: Color,
     /** Background colour for primary actions. State: Rest. */
-    var bgActionPrimaryRest by mutableStateOf(bgActionPrimaryRest)
-        private set
+    val bgActionPrimaryRest: Color,
     /** Background colour for secondary actions. State: Hover. */
-    var bgActionSecondaryHovered by mutableStateOf(bgActionSecondaryHovered)
-        private set
+    val bgActionSecondaryHovered: Color,
     /** Background colour for secondary actions. State: Pressed. */
-    var bgActionSecondaryPressed by mutableStateOf(bgActionSecondaryPressed)
-        private set
+    val bgActionSecondaryPressed: Color,
     /** Background colour for secondary actions. State: Rest. */
-    var bgActionSecondaryRest by mutableStateOf(bgActionSecondaryRest)
-        private set
-    /** Default global background for the user interface.
-Elevation: Default (Level 0) */
-    var bgCanvasDefault by mutableStateOf(bgCanvasDefault)
-        private set
+    val bgActionSecondaryRest: Color,
+    /** Default global background for the user interface. Elevation: Default (Level 0) */
+    val bgCanvasDefault: Color,
     /** Default background for disabled elements. There's no minimum contrast requirement. */
-    var bgCanvasDisabled by mutableStateOf(bgCanvasDisabled)
-        private set
+    val bgCanvasDisabled: Color,
     /** High-contrast background color for critical state. State: Hover. */
-    var bgCriticalHovered by mutableStateOf(bgCriticalHovered)
-        private set
+    val bgCriticalHovered: Color,
     /** High-contrast background color for critical state. State: Rest. */
-    var bgCriticalPrimary by mutableStateOf(bgCriticalPrimary)
-        private set
+    val bgCriticalPrimary: Color,
     /** Default subtle critical surfaces. State: Rest. */
-    var bgCriticalSubtle by mutableStateOf(bgCriticalSubtle)
-        private set
+    val bgCriticalSubtle: Color,
     /** Default subtle critical surfaces. State: Hover. */
-    var bgCriticalSubtleHovered by mutableStateOf(bgCriticalSubtleHovered)
-        private set
+    val bgCriticalSubtleHovered: Color,
     /** Decorative background (1, Lime) for avatars and usernames. */
-    var bgDecorative1 by mutableStateOf(bgDecorative1)
-        private set
+    val bgDecorative1: Color,
     /** Decorative background (2, Cyan) for avatars and usernames. */
-    var bgDecorative2 by mutableStateOf(bgDecorative2)
-        private set
+    val bgDecorative2: Color,
     /** Decorative background (3, Fuchsia) for avatars and usernames. */
-    var bgDecorative3 by mutableStateOf(bgDecorative3)
-        private set
+    val bgDecorative3: Color,
     /** Decorative background (4, Purple) for avatars and usernames. */
-    var bgDecorative4 by mutableStateOf(bgDecorative4)
-        private set
+    val bgDecorative4: Color,
     /** Decorative background (5, Pink) for avatars and usernames. */
-    var bgDecorative5 by mutableStateOf(bgDecorative5)
-        private set
+    val bgDecorative5: Color,
     /** Decorative background (6, Orange) for avatars and usernames. */
-    var bgDecorative6 by mutableStateOf(bgDecorative6)
-        private set
+    val bgDecorative6: Color,
     /** Subtle background colour for informational elements. State: Rest. */
-    var bgInfoSubtle by mutableStateOf(bgInfoSubtle)
-        private set
-    /** Medium contrast surfaces.
-Elevation: Default (Level 2). */
-    var bgSubtlePrimary by mutableStateOf(bgSubtlePrimary)
-        private set
-    /** Low contrast surfaces.
-Elevation: Default (Level 1). */
-    var bgSubtleSecondary by mutableStateOf(bgSubtleSecondary)
-        private set
+    val bgInfoSubtle: Color,
+    /** Medium contrast surfaces. Elevation: Default (Level 2). */
+    val bgSubtlePrimary: Color,
+    /** Low contrast surfaces. Elevation: Default (Level 1). */
+    val bgSubtleSecondary: Color,
     /** Subtle background colour for success state elements. State: Rest. */
-    var bgSuccessSubtle by mutableStateOf(bgSuccessSubtle)
-        private set
+    val bgSuccessSubtle: Color,
     /** High-contrast border for critical state. State: Hover. */
-    var borderCriticalHovered by mutableStateOf(borderCriticalHovered)
-        private set
+    val borderCriticalHovered: Color,
     /** High-contrast border for critical state. State: Rest. */
-    var borderCriticalPrimary by mutableStateOf(borderCriticalPrimary)
-        private set
+    val borderCriticalPrimary: Color,
     /** Subtle border colour for critical state elements. */
-    var borderCriticalSubtle by mutableStateOf(borderCriticalSubtle)
-        private set
+    val borderCriticalSubtle: Color,
     /** Used for borders of disabled elements. There's no minimum contrast requirement. */
-    var borderDisabled by mutableStateOf(borderDisabled)
-        private set
+    val borderDisabled: Color,
     /** Used for the focus state outline. */
-    var borderFocused by mutableStateOf(borderFocused)
-        private set
+    val borderFocused: Color,
     /** Subtle border colour for informational elements. */
-    var borderInfoSubtle by mutableStateOf(borderInfoSubtle)
-        private set
+    val borderInfoSubtle: Color,
     /** Default contrast for accessible interactive element borders. State: Hover. */
-    var borderInteractiveHovered by mutableStateOf(borderInteractiveHovered)
-        private set
+    val borderInteractiveHovered: Color,
     /** Default contrast for accessible interactive element borders. State: Rest. */
-    var borderInteractivePrimary by mutableStateOf(borderInteractivePrimary)
-        private set
+    val borderInteractivePrimary: Color,
     /** ⚠️ Lowest contrast for non-accessible interactive element borders, <3:1. Only use for non-essential borders. Do not rely exclusively on them. State: Rest. */
-    var borderInteractiveSecondary by mutableStateOf(borderInteractiveSecondary)
-        private set
+    val borderInteractiveSecondary: Color,
     /** Subtle border colour for success state elements. */
-    var borderSuccessSubtle by mutableStateOf(borderSuccessSubtle)
-        private set
+    val borderSuccessSubtle: Color,
     /** Lowest contrast accessible accent icons. */
-    var iconAccentTertiary by mutableStateOf(iconAccentTertiary)
-        private set
+    val iconAccentTertiary: Color,
     /** High-contrast icon for critical state. State: Rest. */
-    var iconCriticalPrimary by mutableStateOf(iconCriticalPrimary)
-        private set
+    val iconCriticalPrimary: Color,
     /** Use for icons in disabled elements. There's no minimum contrast requirement. */
-    var iconDisabled by mutableStateOf(iconDisabled)
-        private set
+    val iconDisabled: Color,
     /** High-contrast icon for informational elements. */
-    var iconInfoPrimary by mutableStateOf(iconInfoPrimary)
-        private set
+    val iconInfoPrimary: Color,
     /** Highest contrast icon color on top of high-contrast solid backgrounds like primary, accent, or destructive actions. */
-    var iconOnSolidPrimary by mutableStateOf(iconOnSolidPrimary)
-        private set
+    val iconOnSolidPrimary: Color,
     /** Highest contrast icons. */
-    var iconPrimary by mutableStateOf(iconPrimary)
-        private set
+    val iconPrimary: Color,
     /** Translucent version of primary icon. Refer to it for intended use. */
-    var iconPrimaryAlpha by mutableStateOf(iconPrimaryAlpha)
-        private set
+    val iconPrimaryAlpha: Color,
     /** ⚠️ Lowest contrast non-accessible icons, <3:1. Only use for non-essential icons. Do not rely exclusively on them. */
-    var iconQuaternary by mutableStateOf(iconQuaternary)
-        private set
+    val iconQuaternary: Color,
     /** Translucent version of quaternary icon. Refer to it for intended use. */
-    var iconQuaternaryAlpha by mutableStateOf(iconQuaternaryAlpha)
-        private set
+    val iconQuaternaryAlpha: Color,
     /** Lower contrast icons. */
-    var iconSecondary by mutableStateOf(iconSecondary)
-        private set
+    val iconSecondary: Color,
     /** Translucent version of secondary icon. Refer to it for intended use. */
-    var iconSecondaryAlpha by mutableStateOf(iconSecondaryAlpha)
-        private set
+    val iconSecondaryAlpha: Color,
     /** High-contrast icon for success state elements. */
-    var iconSuccessPrimary by mutableStateOf(iconSuccessPrimary)
-        private set
+    val iconSuccessPrimary: Color,
     /** Lowest contrast accessible icons. */
-    var iconTertiary by mutableStateOf(iconTertiary)
-        private set
+    val iconTertiary: Color,
     /** Translucent version of tertiary icon. Refer to it for intended use. */
-    var iconTertiaryAlpha by mutableStateOf(iconTertiaryAlpha)
-        private set
+    val iconTertiaryAlpha: Color,
     /** Accent text colour for plain actions. */
-    var textActionAccent by mutableStateOf(textActionAccent)
-        private set
+    val textActionAccent: Color,
     /** Default text colour for plain actions. */
-    var textActionPrimary by mutableStateOf(textActionPrimary)
-        private set
+    val textActionPrimary: Color,
     /** Text colour for destructive plain actions. */
-    var textCriticalPrimary by mutableStateOf(textCriticalPrimary)
-        private set
+    val textCriticalPrimary: Color,
     /** Decorative text colour (1, Lime) for avatars and usernames. */
-    var textDecorative1 by mutableStateOf(textDecorative1)
-        private set
+    val textDecorative1: Color,
     /** Decorative text colour (2, Cyan) for avatars and usernames. */
-    var textDecorative2 by mutableStateOf(textDecorative2)
-        private set
+    val textDecorative2: Color,
     /** Decorative text colour (3, Fuchsia) for avatars and usernames. */
-    var textDecorative3 by mutableStateOf(textDecorative3)
-        private set
+    val textDecorative3: Color,
     /** Decorative text colour (4, Purple) for avatars and usernames. */
-    var textDecorative4 by mutableStateOf(textDecorative4)
-        private set
+    val textDecorative4: Color,
     /** Decorative text colour (5, Pink) for avatars and usernames. */
-    var textDecorative5 by mutableStateOf(textDecorative5)
-        private set
+    val textDecorative5: Color,
     /** Decorative text colour (6, Orange) for avatars and usernames. */
-    var textDecorative6 by mutableStateOf(textDecorative6)
-        private set
+    val textDecorative6: Color,
     /** Use for regular text in disabled elements. There's no minimum contrast requirement. */
-    var textDisabled by mutableStateOf(textDisabled)
-        private set
+    val textDisabled: Color,
     /** Accent text colour for informational elements. */
-    var textInfoPrimary by mutableStateOf(textInfoPrimary)
-        private set
+    val textInfoPrimary: Color,
     /** Text colour for external links. */
-    var textLinkExternal by mutableStateOf(textLinkExternal)
-        private set
+    val textLinkExternal: Color,
     /** For use as text color on top of high-contrast solid backgrounds like primary, accent, or destructive actions. */
-    var textOnSolidPrimary by mutableStateOf(textOnSolidPrimary)
-        private set
+    val textOnSolidPrimary: Color,
     /** Use for placeholder text. Placeholder text should be non-essential. Do not rely exclusively on it. */
-    var textPlaceholder by mutableStateOf(textPlaceholder)
-        private set
+    val textPlaceholder: Color,
     /** Highest contrast text. */
-    var textPrimary by mutableStateOf(textPrimary)
-        private set
+    val textPrimary: Color,
     /** Lowest contrast text. */
-    var textSecondary by mutableStateOf(textSecondary)
-        private set
+    val textSecondary: Color,
     /** Accent text colour for success state elements. */
-    var textSuccessPrimary by mutableStateOf(textSuccessPrimary)
-        private set
-
-    fun copy(
-        bgAccentHovered: Color = this.bgAccentHovered,
-        bgAccentPressed: Color = this.bgAccentPressed,
-        bgAccentRest: Color = this.bgAccentRest,
-        bgActionPrimaryDisabled: Color = this.bgActionPrimaryDisabled,
-        bgActionPrimaryHovered: Color = this.bgActionPrimaryHovered,
-        bgActionPrimaryPressed: Color = this.bgActionPrimaryPressed,
-        bgActionPrimaryRest: Color = this.bgActionPrimaryRest,
-        bgActionSecondaryHovered: Color = this.bgActionSecondaryHovered,
-        bgActionSecondaryPressed: Color = this.bgActionSecondaryPressed,
-        bgActionSecondaryRest: Color = this.bgActionSecondaryRest,
-        bgCanvasDefault: Color = this.bgCanvasDefault,
-        bgCanvasDisabled: Color = this.bgCanvasDisabled,
-        bgCriticalHovered: Color = this.bgCriticalHovered,
-        bgCriticalPrimary: Color = this.bgCriticalPrimary,
-        bgCriticalSubtle: Color = this.bgCriticalSubtle,
-        bgCriticalSubtleHovered: Color = this.bgCriticalSubtleHovered,
-        bgDecorative1: Color = this.bgDecorative1,
-        bgDecorative2: Color = this.bgDecorative2,
-        bgDecorative3: Color = this.bgDecorative3,
-        bgDecorative4: Color = this.bgDecorative4,
-        bgDecorative5: Color = this.bgDecorative5,
-        bgDecorative6: Color = this.bgDecorative6,
-        bgInfoSubtle: Color = this.bgInfoSubtle,
-        bgSubtlePrimary: Color = this.bgSubtlePrimary,
-        bgSubtleSecondary: Color = this.bgSubtleSecondary,
-        bgSuccessSubtle: Color = this.bgSuccessSubtle,
-        borderCriticalHovered: Color = this.borderCriticalHovered,
-        borderCriticalPrimary: Color = this.borderCriticalPrimary,
-        borderCriticalSubtle: Color = this.borderCriticalSubtle,
-        borderDisabled: Color = this.borderDisabled,
-        borderFocused: Color = this.borderFocused,
-        borderInfoSubtle: Color = this.borderInfoSubtle,
-        borderInteractiveHovered: Color = this.borderInteractiveHovered,
-        borderInteractivePrimary: Color = this.borderInteractivePrimary,
-        borderInteractiveSecondary: Color = this.borderInteractiveSecondary,
-        borderSuccessSubtle: Color = this.borderSuccessSubtle,
-        iconAccentTertiary: Color = this.iconAccentTertiary,
-        iconCriticalPrimary: Color = this.iconCriticalPrimary,
-        iconDisabled: Color = this.iconDisabled,
-        iconInfoPrimary: Color = this.iconInfoPrimary,
-        iconOnSolidPrimary: Color = this.iconOnSolidPrimary,
-        iconPrimary: Color = this.iconPrimary,
-        iconPrimaryAlpha: Color = this.iconPrimaryAlpha,
-        iconQuaternary: Color = this.iconQuaternary,
-        iconQuaternaryAlpha: Color = this.iconQuaternaryAlpha,
-        iconSecondary: Color = this.iconSecondary,
-        iconSecondaryAlpha: Color = this.iconSecondaryAlpha,
-        iconSuccessPrimary: Color = this.iconSuccessPrimary,
-        iconTertiary: Color = this.iconTertiary,
-        iconTertiaryAlpha: Color = this.iconTertiaryAlpha,
-        textActionAccent: Color = this.textActionAccent,
-        textActionPrimary: Color = this.textActionPrimary,
-        textCriticalPrimary: Color = this.textCriticalPrimary,
-        textDecorative1: Color = this.textDecorative1,
-        textDecorative2: Color = this.textDecorative2,
-        textDecorative3: Color = this.textDecorative3,
-        textDecorative4: Color = this.textDecorative4,
-        textDecorative5: Color = this.textDecorative5,
-        textDecorative6: Color = this.textDecorative6,
-        textDisabled: Color = this.textDisabled,
-        textInfoPrimary: Color = this.textInfoPrimary,
-        textLinkExternal: Color = this.textLinkExternal,
-        textOnSolidPrimary: Color = this.textOnSolidPrimary,
-        textPlaceholder: Color = this.textPlaceholder,
-        textPrimary: Color = this.textPrimary,
-        textSecondary: Color = this.textSecondary,
-        textSuccessPrimary: Color = this.textSuccessPrimary,
-        isLight: Boolean = this.isLight,
-    ) = SemanticColors(
-        bgAccentHovered = bgAccentHovered,
-        bgAccentPressed = bgAccentPressed,
-        bgAccentRest = bgAccentRest,
-        bgActionPrimaryDisabled = bgActionPrimaryDisabled,
-        bgActionPrimaryHovered = bgActionPrimaryHovered,
-        bgActionPrimaryPressed = bgActionPrimaryPressed,
-        bgActionPrimaryRest = bgActionPrimaryRest,
-        bgActionSecondaryHovered = bgActionSecondaryHovered,
-        bgActionSecondaryPressed = bgActionSecondaryPressed,
-        bgActionSecondaryRest = bgActionSecondaryRest,
-        bgCanvasDefault = bgCanvasDefault,
-        bgCanvasDisabled = bgCanvasDisabled,
-        bgCriticalHovered = bgCriticalHovered,
-        bgCriticalPrimary = bgCriticalPrimary,
-        bgCriticalSubtle = bgCriticalSubtle,
-        bgCriticalSubtleHovered = bgCriticalSubtleHovered,
-        bgDecorative1 = bgDecorative1,
-        bgDecorative2 = bgDecorative2,
-        bgDecorative3 = bgDecorative3,
-        bgDecorative4 = bgDecorative4,
-        bgDecorative5 = bgDecorative5,
-        bgDecorative6 = bgDecorative6,
-        bgInfoSubtle = bgInfoSubtle,
-        bgSubtlePrimary = bgSubtlePrimary,
-        bgSubtleSecondary = bgSubtleSecondary,
-        bgSuccessSubtle = bgSuccessSubtle,
-        borderCriticalHovered = borderCriticalHovered,
-        borderCriticalPrimary = borderCriticalPrimary,
-        borderCriticalSubtle = borderCriticalSubtle,
-        borderDisabled = borderDisabled,
-        borderFocused = borderFocused,
-        borderInfoSubtle = borderInfoSubtle,
-        borderInteractiveHovered = borderInteractiveHovered,
-        borderInteractivePrimary = borderInteractivePrimary,
-        borderInteractiveSecondary = borderInteractiveSecondary,
-        borderSuccessSubtle = borderSuccessSubtle,
-        iconAccentTertiary = iconAccentTertiary,
-        iconCriticalPrimary = iconCriticalPrimary,
-        iconDisabled = iconDisabled,
-        iconInfoPrimary = iconInfoPrimary,
-        iconOnSolidPrimary = iconOnSolidPrimary,
-        iconPrimary = iconPrimary,
-        iconPrimaryAlpha = iconPrimaryAlpha,
-        iconQuaternary = iconQuaternary,
-        iconQuaternaryAlpha = iconQuaternaryAlpha,
-        iconSecondary = iconSecondary,
-        iconSecondaryAlpha = iconSecondaryAlpha,
-        iconSuccessPrimary = iconSuccessPrimary,
-        iconTertiary = iconTertiary,
-        iconTertiaryAlpha = iconTertiaryAlpha,
-        textActionAccent = textActionAccent,
-        textActionPrimary = textActionPrimary,
-        textCriticalPrimary = textCriticalPrimary,
-        textDecorative1 = textDecorative1,
-        textDecorative2 = textDecorative2,
-        textDecorative3 = textDecorative3,
-        textDecorative4 = textDecorative4,
-        textDecorative5 = textDecorative5,
-        textDecorative6 = textDecorative6,
-        textDisabled = textDisabled,
-        textInfoPrimary = textInfoPrimary,
-        textLinkExternal = textLinkExternal,
-        textOnSolidPrimary = textOnSolidPrimary,
-        textPlaceholder = textPlaceholder,
-        textPrimary = textPrimary,
-        textSecondary = textSecondary,
-        textSuccessPrimary = textSuccessPrimary,
-        isLight = isLight,
-    )
-
-    fun updateColorsFrom(other: SemanticColors) {
-        bgAccentHovered = other.bgAccentHovered
-        bgAccentPressed = other.bgAccentPressed
-        bgAccentRest = other.bgAccentRest
-        bgActionPrimaryDisabled = other.bgActionPrimaryDisabled
-        bgActionPrimaryHovered = other.bgActionPrimaryHovered
-        bgActionPrimaryPressed = other.bgActionPrimaryPressed
-        bgActionPrimaryRest = other.bgActionPrimaryRest
-        bgActionSecondaryHovered = other.bgActionSecondaryHovered
-        bgActionSecondaryPressed = other.bgActionSecondaryPressed
-        bgActionSecondaryRest = other.bgActionSecondaryRest
-        bgCanvasDefault = other.bgCanvasDefault
-        bgCanvasDisabled = other.bgCanvasDisabled
-        bgCriticalHovered = other.bgCriticalHovered
-        bgCriticalPrimary = other.bgCriticalPrimary
-        bgCriticalSubtle = other.bgCriticalSubtle
-        bgCriticalSubtleHovered = other.bgCriticalSubtleHovered
-        bgDecorative1 = other.bgDecorative1
-        bgDecorative2 = other.bgDecorative2
-        bgDecorative3 = other.bgDecorative3
-        bgDecorative4 = other.bgDecorative4
-        bgDecorative5 = other.bgDecorative5
-        bgDecorative6 = other.bgDecorative6
-        bgInfoSubtle = other.bgInfoSubtle
-        bgSubtlePrimary = other.bgSubtlePrimary
-        bgSubtleSecondary = other.bgSubtleSecondary
-        bgSuccessSubtle = other.bgSuccessSubtle
-        borderCriticalHovered = other.borderCriticalHovered
-        borderCriticalPrimary = other.borderCriticalPrimary
-        borderCriticalSubtle = other.borderCriticalSubtle
-        borderDisabled = other.borderDisabled
-        borderFocused = other.borderFocused
-        borderInfoSubtle = other.borderInfoSubtle
-        borderInteractiveHovered = other.borderInteractiveHovered
-        borderInteractivePrimary = other.borderInteractivePrimary
-        borderInteractiveSecondary = other.borderInteractiveSecondary
-        borderSuccessSubtle = other.borderSuccessSubtle
-        iconAccentTertiary = other.iconAccentTertiary
-        iconCriticalPrimary = other.iconCriticalPrimary
-        iconDisabled = other.iconDisabled
-        iconInfoPrimary = other.iconInfoPrimary
-        iconOnSolidPrimary = other.iconOnSolidPrimary
-        iconPrimary = other.iconPrimary
-        iconPrimaryAlpha = other.iconPrimaryAlpha
-        iconQuaternary = other.iconQuaternary
-        iconQuaternaryAlpha = other.iconQuaternaryAlpha
-        iconSecondary = other.iconSecondary
-        iconSecondaryAlpha = other.iconSecondaryAlpha
-        iconSuccessPrimary = other.iconSuccessPrimary
-        iconTertiary = other.iconTertiary
-        iconTertiaryAlpha = other.iconTertiaryAlpha
-        textActionAccent = other.textActionAccent
-        textActionPrimary = other.textActionPrimary
-        textCriticalPrimary = other.textCriticalPrimary
-        textDecorative1 = other.textDecorative1
-        textDecorative2 = other.textDecorative2
-        textDecorative3 = other.textDecorative3
-        textDecorative4 = other.textDecorative4
-        textDecorative5 = other.textDecorative5
-        textDecorative6 = other.textDecorative6
-        textDisabled = other.textDisabled
-        textInfoPrimary = other.textInfoPrimary
-        textLinkExternal = other.textLinkExternal
-        textOnSolidPrimary = other.textOnSolidPrimary
-        textPlaceholder = other.textPlaceholder
-        textPrimary = other.textPrimary
-        textSecondary = other.textSecondary
-        textSuccessPrimary = other.textSuccessPrimary
-        isLight = other.isLight
-    }
-}
+    val textSuccessPrimary: Color,
+    /** True for light theme, false for dark theme. */
+    val isLight: Boolean,
+)

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Let test include roborazzi verification
+# https://github.com/takahirom/roborazzi?tab=readme-ov-file#roborazzitest
+roborazzi.test.verify=true


### PR DESCRIPTION
Iterate on the `ElementTheme` composable parameters to be able to colors for light and dark mode.

Make SemanticColors a simple data class and create extension to create Material color form SemanticColors.

Tested OK locally by importing the code in EXA project, but please review carefully :)