### PR TITLE
Use tag instead of main branch when importing tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # Compound Android
 
-[![](https://img.shields.io/github/license/vector-im/compound)](https://github.com/vector-im/compound/blob/main/LICENSE)
+[![](https://img.shields.io/github/license/element-hq/compound)](https://github.com/element-hq/compound/blob/main/LICENSE)
 
-This module contains the theme tokens for the application, including those auto-generated from [Compound](https://github.com/vector-im/compound-design-tokens) and its mappings.
+This module contains the theme tokens for the application, including those auto-generated from [Compound](https://github.com/element-hq/compound-design-tokens) and its mappings.
 
 ## Importing tokens
 
-To update the token from [Compound](https://github.com/vector-im/compound-design-tokens), you need to set the tag in the file [import_tokens.sh](./scripts/import_tokens.sh) and run the script.
+To update the token from [Compound](https://github.com/element-hq/compound-design-tokens), you need to set the tag in the file [import_tokens.sh](./scripts/import_tokens.sh) and run the script.
 
 It's also possible to provide the tag (or a branch) as a parameter to the script:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 This module contains the theme tokens for the application, including those auto-generated from [Compound](https://github.com/vector-im/compound-design-tokens) and its mappings.
 
+## Importing tokens
+
+To update the token from [Compound](https://github.com/vector-im/compound-design-tokens), you need to set the tag in the file [import_tokens.sh](./scripts/import_tokens.sh) and run the script.
+
+It's also possible to provide the tag (or a branch) as a parameter to the script:
+
+```bash 
+./scripts/import_tokens.sh -t <tag>
+``` 
+
 ## Usage
 
 The module contains public tokens and color schemes that are later used in `MaterialTheme` and added to `ElementTheme` for use in the application.

--- a/compound/src/main/kotlin/io/element/android/compound/tokens/generated/DO_NOT_MODIFY.txt
+++ b/compound/src/main/kotlin/io/element/android/compound/tokens/generated/DO_NOT_MODIFY.txt
@@ -1,1 +1,1 @@
-Files inside this package are generated automatically from the Compound project (https://github.com/vector-im/compound-design-tokens) and will be batch-replaced when new tokens are generated.
+Files inside this package are generated automatically from the Compound project (https://github.com/element-hq/compound-design-tokens) and will be batch-replaced when new tokens are generated.

--- a/scripts/import_tokens.sh
+++ b/scripts/import_tokens.sh
@@ -22,7 +22,7 @@ if [ -d tmp ]; then
 fi
 mkdir tmp
 pushd tmp
-git clone --depth 1 --branch $TAG https://github.com/vector-im/compound-design-tokens
+git clone --depth 1 --branch $TAG https://github.com/element-hq/compound-design-tokens
 
 echo "Copying files from tokens repository..."
 cp -R compound-design-tokens/assets/android/res/drawable ../compound/src/main/res/

--- a/scripts/import_tokens.sh
+++ b/scripts/import_tokens.sh
@@ -2,18 +2,18 @@
 
 set -e
 
-SHORT=b,:
-LONG=branch,:
-BRANCH='main'
+SHORT=t,:
+LONG=tag,:
+TAG='v1.4.0'
 
-while getopts b: flag
+while getopts t: flag
 do
     case "${flag}" in
-        b) BRANCH=${OPTARG};;
+        t) TAG=${OPTARG};;
     esac
 done
 
-echo "Branch used: $BRANCH"
+echo "Tag used: $TAG"
 
 echo "Cloning the compound-design-tokens repository..."
 if [ -d tmp ]; then
@@ -22,7 +22,7 @@ if [ -d tmp ]; then
 fi
 mkdir tmp
 pushd tmp
-git clone --branch $BRANCH https://github.com/vector-im/compound-design-tokens
+git clone --depth 1 --branch $TAG https://github.com/vector-im/compound-design-tokens
 
 echo "Copying files from tokens repository..."
 cp -R compound-design-tokens/assets/android/res/drawable ../compound/src/main/res/


### PR DESCRIPTION
In order to ensure traceability of the token version used per release, use a tag to import the Compound tokens.

Note that it's still possible to use a branch name for testing purpose only.

Also change `vector-im` to `element-hq` in the whole project.