### PR TITLE
Fix material colors

### DIFF
--- a/compound/screenshots/Material3 Colors - Dark HC.png
+++ b/compound/screenshots/Material3 Colors - Dark HC.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b2c04604e6d8de833533e3a210bbe600cc30997ce6d7eb52a6d069b0943e947
-size 160833
+oid sha256:85969829577e158bdd1d0f21c8b3a2334dcde79cb50d5e2331d06d5423332be2
+size 160754

--- a/compound/screenshots/Material3 Colors - Dark.png
+++ b/compound/screenshots/Material3 Colors - Dark.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9396abb677512a8606b4f05116dff978abd8b229305cf9ef08581ad7a477f251
-size 159020
+oid sha256:ca64da1dc373dc49503ee525ae3331e73d0ab12053993a1ef19dcab1e67b08c4
+size 159123

--- a/compound/screenshots/Material3 Colors - Light HC.png
+++ b/compound/screenshots/Material3 Colors - Light HC.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8d263f89a300bda79ce517e6176b8d999a700a235be2ad3f32c6e48a1c7dca0
-size 163209
+oid sha256:01622bca20a132ec5a874fc1a2d0ffd45e7ce6d7849c4d607d79c7bc51d6c6a9
+size 163322

--- a/compound/screenshots/Material3 Colors - Light.png
+++ b/compound/screenshots/Material3 Colors - Light.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:932b3a1316c732a81a8aa26930decc443d4178344fd4493cbb6fee05acbbc774
-size 162802
+oid sha256:87c0c4ff42d17137d554708ce33f40f214ec608eca4ca87af0b2adab63de6bb7
+size 162891

--- a/compound/screenshots/MaterialText Colors.png
+++ b/compound/screenshots/MaterialText Colors.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4be10c3bb9900d27a3b406eca0cb902b0ff9cdf90e8e3cf1ae7760aa7c5d47d9
+size 377446

--- a/compound/src/main/kotlin/io/element/android/compound/previews/CompoundIconsPreview.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/previews/CompoundIconsPreview.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.previews
 
 import androidx.compose.foundation.background

--- a/compound/src/main/kotlin/io/element/android/compound/previews/CompoundIconsPreview.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/previews/CompoundIconsPreview.kt
@@ -32,13 +32,13 @@ import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
 import io.element.android.compound.tokens.generated.CompoundIcons
 
-@Preview(widthDp = 730, heightDp = 1600)
+@Preview(widthDp = 730, heightDp = 1800)
 @Composable
 internal fun IconsCompoundPreviewLight() = ElementTheme {
     IconsCompoundPreview()
 }
 
-@Preview(widthDp = 730, heightDp = 1600)
+@Preview(widthDp = 730, heightDp = 1800)
 @Composable
 internal fun IconsCompoundPreviewRtl() = ElementTheme {
     CompositionLocalProvider(
@@ -50,7 +50,7 @@ internal fun IconsCompoundPreviewRtl() = ElementTheme {
     }
 }
 
-@Preview(widthDp = 730, heightDp = 1600)
+@Preview(widthDp = 730, heightDp = 1800)
 @Composable
 internal fun IconsCompoundPreviewDark() = ElementTheme(darkTheme = true) {
     IconsCompoundPreview()

--- a/compound/src/main/kotlin/io/element/android/compound/previews/Typography.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/previews/Typography.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.compound.previews
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.element.android.compound.theme.ElementTheme
+
+@Preview
+@Composable
+fun TypographyPreview() = ElementTheme {
+    Surface {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            with(ElementTheme.materialTypography) {
+                TypographyTokenPreview(displayLarge, "Display large")
+                TypographyTokenPreview(displayMedium, "Display medium")
+                TypographyTokenPreview(displaySmall, "Display small")
+                TypographyTokenPreview(headlineLarge, "Headline large")
+                TypographyTokenPreview(headlineMedium, "Headline medium")
+                TypographyTokenPreview(headlineSmall, "Headline small")
+                TypographyTokenPreview(titleLarge, "Title large")
+                TypographyTokenPreview(titleMedium, "Title medium")
+                TypographyTokenPreview(titleSmall, "Title small")
+                TypographyTokenPreview(bodyLarge, "Body large")
+                TypographyTokenPreview(bodyMedium, "Body medium")
+                TypographyTokenPreview(bodySmall, "Body small")
+                TypographyTokenPreview(labelLarge, "Label large")
+                TypographyTokenPreview(labelMedium, "Label medium")
+                TypographyTokenPreview(labelSmall, "Label small")
+            }
+        }
+    }
+}
+
+@Composable
+private fun TypographyTokenPreview(style: TextStyle, text: String) {
+    Text(text = text, style = style)
+}

--- a/compound/src/main/kotlin/io/element/android/compound/theme/AvatarColors.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/AvatarColors.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.theme
 
 import androidx.compose.foundation.background

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeDark.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeDark.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.compound.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.darkColorScheme
+import io.element.android.compound.annotations.CoreColorToken
+import io.element.android.compound.tokens.generated.SemanticColors
+import io.element.android.compound.tokens.generated.internal.DarkColorTokens
+
+@OptIn(CoreColorToken::class)
+fun SemanticColors.toMaterialColorSchemeDark(): ColorScheme = darkColorScheme(
+    primary = textPrimary,
+    onPrimary = textOnSolidPrimary,
+    primaryContainer = textOnSolidPrimary,
+    onPrimaryContainer = textPrimary,
+    inversePrimary = textOnSolidPrimary,
+    secondary = textSecondary,
+    onSecondary = textOnSolidPrimary,
+    secondaryContainer = bgSubtlePrimary,
+    onSecondaryContainer = textPrimary,
+    tertiary = textSecondary,
+    onTertiary = textOnSolidPrimary,
+    tertiaryContainer = textPrimary,
+    onTertiaryContainer = textOnSolidPrimary,
+    background = textOnSolidPrimary,
+    onBackground = textPrimary,
+    surface = textOnSolidPrimary,
+    onSurface = textPrimary,
+    surfaceVariant = DarkColorTokens.colorGray300,
+    onSurfaceVariant = iconSecondary,
+    surfaceTint = DarkColorTokens.colorGray1000,
+    inverseSurface = DarkColorTokens.colorGray1300,
+    inverseOnSurface = textOnSolidPrimary,
+    error = bgCriticalPrimary,
+    onError = textOnSolidPrimary,
+    errorContainer = DarkColorTokens.colorRed400,
+    onErrorContainer = textCriticalPrimary,
+    outline = iconSecondary,
+    outlineVariant = DarkColorTokens.colorAlphaGray400,
+    scrim = bgSubtleSecondary,
+)

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeDark.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeDark.kt
@@ -48,5 +48,5 @@ fun SemanticColors.toMaterialColorSchemeDark(): ColorScheme = darkColorScheme(
     outline = borderInteractivePrimary,
     outlineVariant = DarkColorTokens.colorAlphaGray400,
     // Note: for light it will be colorGray1400
-    scrim = DarkColorTokens.colorGray300.copy(alpha = 0.32f),
+    scrim = DarkColorTokens.colorGray300,
 )

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeDark.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeDark.kt
@@ -13,11 +13,15 @@ import io.element.android.compound.annotations.CoreColorToken
 import io.element.android.compound.tokens.generated.SemanticColors
 import io.element.android.compound.tokens.generated.internal.DarkColorTokens
 
+/**
+ * See the mapping in
+ * https://www.figma.com/design/G1xy0HDZKJf5TCRFmKb5d5/Compound-Android-Components?node-id=311-14&p=f&t=QcVyNaPEZMDA6RFK-0
+ */
 @OptIn(CoreColorToken::class)
 fun SemanticColors.toMaterialColorSchemeDark(): ColorScheme = darkColorScheme(
-    primary = textPrimary,
+    primary = bgActionPrimaryRest,
     onPrimary = textOnSolidPrimary,
-    primaryContainer = textOnSolidPrimary,
+    primaryContainer = bgCanvasDefault,
     onPrimaryContainer = textPrimary,
     inversePrimary = textOnSolidPrimary,
     secondary = textSecondary,
@@ -26,22 +30,23 @@ fun SemanticColors.toMaterialColorSchemeDark(): ColorScheme = darkColorScheme(
     onSecondaryContainer = textPrimary,
     tertiary = textSecondary,
     onTertiary = textOnSolidPrimary,
-    tertiaryContainer = textPrimary,
+    tertiaryContainer = bgActionPrimaryRest,
     onTertiaryContainer = textOnSolidPrimary,
-    background = textOnSolidPrimary,
+    background = bgCanvasDefault,
     onBackground = textPrimary,
-    surface = textOnSolidPrimary,
+    surface = bgCanvasDefault,
     onSurface = textPrimary,
-    surfaceVariant = DarkColorTokens.colorGray300,
-    onSurfaceVariant = iconSecondary,
+    surfaceVariant = bgSubtleSecondary,
+    onSurfaceVariant = textSecondary,
     surfaceTint = DarkColorTokens.colorGray1000,
     inverseSurface = DarkColorTokens.colorGray1300,
     inverseOnSurface = textOnSolidPrimary,
-    error = bgCriticalPrimary,
+    error = textCriticalPrimary,
     onError = textOnSolidPrimary,
     errorContainer = DarkColorTokens.colorRed400,
     onErrorContainer = textCriticalPrimary,
-    outline = iconSecondary,
+    outline = borderInteractivePrimary,
     outlineVariant = DarkColorTokens.colorAlphaGray400,
-    scrim = bgSubtleSecondary,
+    // Note: for light it will be colorGray1400
+    scrim = DarkColorTokens.colorGray300.copy(alpha = 0.32f),
 )

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeLight.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeLight.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.compound.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.lightColorScheme
+import io.element.android.compound.annotations.CoreColorToken
+import io.element.android.compound.tokens.generated.SemanticColors
+import io.element.android.compound.tokens.generated.internal.LightColorTokens
+
+@OptIn(CoreColorToken::class)
+fun SemanticColors.toMaterialColorSchemeLight(): ColorScheme = lightColorScheme(
+    primary = textPrimary,
+    onPrimary = textOnSolidPrimary,
+    primaryContainer = textOnSolidPrimary,
+    onPrimaryContainer = textPrimary,
+    inversePrimary = textOnSolidPrimary,
+    secondary = textSecondary,
+    onSecondary = textOnSolidPrimary,
+    secondaryContainer = bgSubtlePrimary,
+    onSecondaryContainer = textPrimary,
+    tertiary = textSecondary,
+    onTertiary = textOnSolidPrimary,
+    tertiaryContainer = textPrimary,
+    onTertiaryContainer = textOnSolidPrimary,
+    background = textOnSolidPrimary,
+    onBackground = textPrimary,
+    surface = textOnSolidPrimary,
+    onSurface = textPrimary,
+    surfaceVariant = LightColorTokens.colorGray300,
+    onSurfaceVariant = iconSecondary,
+    surfaceTint = LightColorTokens.colorGray1000,
+    inverseSurface = LightColorTokens.colorGray1300,
+    inverseOnSurface = textOnSolidPrimary,
+    error = bgCriticalPrimary,
+    onError = textOnSolidPrimary,
+    errorContainer = LightColorTokens.colorRed400,
+    onErrorContainer = textCriticalPrimary,
+    outline = iconSecondary,
+    outlineVariant = LightColorTokens.colorAlphaGray400,
+    scrim = textPrimary,
+)

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeLight.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeLight.kt
@@ -13,11 +13,15 @@ import io.element.android.compound.annotations.CoreColorToken
 import io.element.android.compound.tokens.generated.SemanticColors
 import io.element.android.compound.tokens.generated.internal.LightColorTokens
 
+/**
+ * See the mapping in
+ * https://www.figma.com/design/G1xy0HDZKJf5TCRFmKb5d5/Compound-Android-Components?node-id=311-14&p=f&t=QcVyNaPEZMDA6RFK-0
+ */
 @OptIn(CoreColorToken::class)
 fun SemanticColors.toMaterialColorSchemeLight(): ColorScheme = lightColorScheme(
-    primary = textPrimary,
+    primary = bgActionPrimaryRest,
     onPrimary = textOnSolidPrimary,
-    primaryContainer = textOnSolidPrimary,
+    primaryContainer = bgCanvasDefault,
     onPrimaryContainer = textPrimary,
     inversePrimary = textOnSolidPrimary,
     secondary = textSecondary,
@@ -26,22 +30,23 @@ fun SemanticColors.toMaterialColorSchemeLight(): ColorScheme = lightColorScheme(
     onSecondaryContainer = textPrimary,
     tertiary = textSecondary,
     onTertiary = textOnSolidPrimary,
-    tertiaryContainer = textPrimary,
+    tertiaryContainer = bgActionPrimaryRest,
     onTertiaryContainer = textOnSolidPrimary,
-    background = textOnSolidPrimary,
+    background = bgCanvasDefault,
     onBackground = textPrimary,
-    surface = textOnSolidPrimary,
+    surface = bgCanvasDefault,
     onSurface = textPrimary,
-    surfaceVariant = LightColorTokens.colorGray300,
-    onSurfaceVariant = iconSecondary,
+    surfaceVariant = bgSubtleSecondary,
+    onSurfaceVariant = textSecondary,
     surfaceTint = LightColorTokens.colorGray1000,
     inverseSurface = LightColorTokens.colorGray1300,
     inverseOnSurface = textOnSolidPrimary,
-    error = bgCriticalPrimary,
+    error = textCriticalPrimary, 
     onError = textOnSolidPrimary,
     errorContainer = LightColorTokens.colorRed400,
     onErrorContainer = textCriticalPrimary,
-    outline = iconSecondary,
+    outline = borderInteractivePrimary,
     outlineVariant = LightColorTokens.colorAlphaGray400,
-    scrim = textPrimary,
+    // Note: for dark it will be colorGray300
+    scrim = LightColorTokens.colorGray1400.copy(alpha = 0.32f),
 )

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeLight.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialColorSchemeLight.kt
@@ -41,12 +41,12 @@ fun SemanticColors.toMaterialColorSchemeLight(): ColorScheme = lightColorScheme(
     surfaceTint = LightColorTokens.colorGray1000,
     inverseSurface = LightColorTokens.colorGray1300,
     inverseOnSurface = textOnSolidPrimary,
-    error = textCriticalPrimary, 
+    error = textCriticalPrimary,
     onError = textOnSolidPrimary,
     errorContainer = LightColorTokens.colorRed400,
     onErrorContainer = textCriticalPrimary,
     outline = borderInteractivePrimary,
     outlineVariant = LightColorTokens.colorAlphaGray400,
     // Note: for dark it will be colorGray300
-    scrim = LightColorTokens.colorGray1400.copy(alpha = 0.32f),
+    scrim = LightColorTokens.colorGray1400,
 )

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialTextPreview.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialTextPreview.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.compound.theme
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.element.android.compound.utils.toHrf
+
+@Preview(heightDp = 1200, widthDp = 420)
+@Composable
+internal fun MaterialTextPreview() = Row(
+    modifier = Modifier.background(Color.Yellow)
+) {
+    MaterialPreview(
+        modifier = Modifier.weight(1f),
+        darkTheme = false,
+    )
+    MaterialPreview(
+        modifier = Modifier.weight(1f),
+        darkTheme = true,
+    )
+}
+
+private data class Model(
+    val name: String,
+    val bgColor: Color,
+    val textColor: Color,
+)
+
+@Composable
+private fun MaterialPreview(
+    darkTheme: Boolean,
+    modifier: Modifier = Modifier,
+) = Column(modifier = modifier) {
+    Text(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        textAlign = TextAlign.Center,
+        text = if (darkTheme) "Dark" else "Light",
+        color = Color.Black,
+        fontSize = 18.sp,
+        fontWeight = FontWeight.Bold,
+    )
+    ElementTheme(
+        darkTheme = darkTheme,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            listOf(
+                Model("Background", MaterialTheme.colorScheme.background, MaterialTheme.colorScheme.onBackground),
+                Model("Primary", MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.onPrimary),
+                Model("PrimaryContainer", MaterialTheme.colorScheme.primaryContainer, MaterialTheme.colorScheme.onPrimaryContainer),
+                Model("Secondary", MaterialTheme.colorScheme.secondary, MaterialTheme.colorScheme.onSecondary),
+                Model("SecondaryContainer", MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.onSecondaryContainer),
+                Model("Tertiary", MaterialTheme.colorScheme.tertiary, MaterialTheme.colorScheme.onTertiary),
+                Model("TertiaryContainer", MaterialTheme.colorScheme.tertiaryContainer, MaterialTheme.colorScheme.onTertiaryContainer),
+                Model("Surface", MaterialTheme.colorScheme.surface, MaterialTheme.colorScheme.onSurface),
+                Model("SurfaceVariant", MaterialTheme.colorScheme.surfaceVariant, MaterialTheme.colorScheme.onSurfaceVariant),
+                Model("InverseSurface", MaterialTheme.colorScheme.inverseSurface, MaterialTheme.colorScheme.inverseOnSurface),
+                Model("Error", MaterialTheme.colorScheme.error, MaterialTheme.colorScheme.onError),
+                Model("ErrorContainer", MaterialTheme.colorScheme.errorContainer, MaterialTheme.colorScheme.onErrorContainer),
+            ).forEach {
+                TextPreview(
+                    name = it.name,
+                    bgColor = it.bgColor,
+                    textColor = it.textColor,
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .padding(1.dp)
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.background)
+            ) {
+                Text(
+                    text = "Below\n".repeat(3),
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Text(
+                    modifier = Modifier
+                        .padding(12.dp)
+                        .fillMaxWidth()
+                        .background(color = MaterialTheme.colorScheme.scrim)
+                        .padding(16.dp),
+                    text = "${"Scrim"}\n${MaterialTheme.colorScheme.scrim.toHrf()}",
+                    style = LocalTextStyle.current.copy(fontFamily = FontFamily.Monospace),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+        }
+    }
+}
+
+
+@Composable
+private fun TextPreview(
+    name: String,
+    bgColor: Color,
+    textColor: Color,
+    modifier: Modifier = Modifier,
+) = Text(
+    modifier = modifier
+        .padding(1.dp)
+        .fillMaxWidth()
+        .background(bgColor)
+        .padding(horizontal = 16.dp, vertical = 8.dp),
+    text = "$name\n${textColor.toHrf()}\n${bgColor.toHrf()}",
+    style = LocalTextStyle.current.copy(fontFamily = FontFamily.Monospace),
+    textAlign = TextAlign.Center,
+    color = textColor,
+)

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialTextPreview.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialTextPreview.kt
@@ -104,7 +104,10 @@ private fun MaterialPreview(
                     modifier = Modifier
                         .padding(12.dp)
                         .fillMaxWidth()
-                        .background(color = MaterialTheme.colorScheme.scrim)
+                        // the alpha applied to the scrim color does not seem to be mandatory.
+                        // The library ignores the alpha level provided and apply it's own.
+                        // For testing the color, manually set an alpha.
+                        .background(color = MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f))
                         .padding(16.dp),
                     text = "${"Scrim"}\n${MaterialTheme.colorScheme.scrim.toHrf()}",
                     style = LocalTextStyle.current.copy(fontFamily = FontFamily.Monospace),

--- a/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
+++ b/compound/src/main/kotlin/io/element/android/compound/theme/MaterialThemeColors.kt
@@ -8,85 +8,19 @@
 package io.element.android.compound.theme
 
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import io.element.android.compound.annotations.CoreColorToken
 import io.element.android.compound.previews.ColorsSchemePreview
 import io.element.android.compound.tokens.generated.SemanticColors
 import io.element.android.compound.tokens.generated.compoundColorsHcDark
 import io.element.android.compound.tokens.generated.compoundColorsHcLight
-import io.element.android.compound.tokens.generated.internal.DarkColorTokens
-import io.element.android.compound.tokens.generated.internal.LightColorTokens
 
-@OptIn(CoreColorToken::class)
 fun SemanticColors.toMaterialColorScheme(): ColorScheme {
     return if (isLight) {
-        lightColorScheme(
-            primary = textPrimary,
-            onPrimary = textOnSolidPrimary,
-            primaryContainer = textOnSolidPrimary,
-            onPrimaryContainer = textPrimary,
-            inversePrimary = textOnSolidPrimary,
-            secondary = textSecondary,
-            onSecondary = textOnSolidPrimary,
-            secondaryContainer = bgSubtlePrimary,
-            onSecondaryContainer = textPrimary,
-            tertiary = textSecondary,
-            onTertiary = textOnSolidPrimary,
-            tertiaryContainer = textPrimary,
-            onTertiaryContainer = textOnSolidPrimary,
-            background = textOnSolidPrimary,
-            onBackground = textPrimary,
-            surface = textOnSolidPrimary,
-            onSurface = textPrimary,
-            surfaceVariant = LightColorTokens.colorGray300,
-            onSurfaceVariant = iconSecondary,
-            surfaceTint = LightColorTokens.colorGray1000,
-            inverseSurface = LightColorTokens.colorGray1300,
-            inverseOnSurface = textOnSolidPrimary,
-            error = bgCriticalPrimary,
-            onError = textOnSolidPrimary,
-            errorContainer = LightColorTokens.colorRed400,
-            onErrorContainer = textCriticalPrimary,
-            outline = iconSecondary,
-            outlineVariant = LightColorTokens.colorAlphaGray400,
-            scrim = textPrimary,
-        )
+        toMaterialColorSchemeLight()
     } else {
-        darkColorScheme(
-            primary = textPrimary,
-            onPrimary = textOnSolidPrimary,
-            primaryContainer = textOnSolidPrimary,
-            onPrimaryContainer = textPrimary,
-            inversePrimary = textOnSolidPrimary,
-            secondary = textSecondary,
-            onSecondary = textOnSolidPrimary,
-            secondaryContainer = bgSubtlePrimary,
-            onSecondaryContainer = textPrimary,
-            tertiary = textSecondary,
-            onTertiary = textOnSolidPrimary,
-            tertiaryContainer = textPrimary,
-            onTertiaryContainer = textOnSolidPrimary,
-            background = textOnSolidPrimary,
-            onBackground = textPrimary,
-            surface = textOnSolidPrimary,
-            onSurface = textPrimary,
-            surfaceVariant = DarkColorTokens.colorGray300,
-            onSurfaceVariant = iconSecondary,
-            surfaceTint = DarkColorTokens.colorGray1000,
-            inverseSurface = DarkColorTokens.colorGray1300,
-            inverseOnSurface = textOnSolidPrimary,
-            error = bgCriticalPrimary,
-            onError = textOnSolidPrimary,
-            errorContainer = DarkColorTokens.colorRed400,
-            onErrorContainer = textCriticalPrimary,
-            outline = iconSecondary,
-            outlineVariant = DarkColorTokens.colorAlphaGray400,
-            scrim = bgSubtleSecondary,
-        )
+        toMaterialColorSchemeDark()
     }
 }
 

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/AvatarColorsTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/AvatarColorsTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/CompoundIconTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/CompoundIconTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot
 
 import androidx.compose.foundation.layout.ColumnScope

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/CompoundTypographyTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/CompoundTypographyTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot
 
 import androidx.compose.foundation.layout.Arrangement

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/ForcedDarkElementThemeTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/ForcedDarkElementThemeTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot
 
 import androidx.compose.foundation.layout.Arrangement

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/LegacyColorsTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/LegacyColorsTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot
 
 import androidx.compose.foundation.layout.Column

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialColorSchemeTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialColorSchemeTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot
 
 import androidx.compose.foundation.layout.Column

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialTextTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialTextTests.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
+package io.element.android.compound.screenshot
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.takahirom.roborazzi.captureRoboImage
+import io.element.android.compound.screenshot.utils.screenshotFile
+import io.element.android.compound.theme.MaterialTextPreview
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(AndroidJUnit4::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class MaterialTextTests {
+    @Test
+    @Config(sdk = [35], qualifiers = "w480dp-h1200dp-xxhdpi")
+    fun screenshots() {
+        captureRoboImage(file = screenshotFile("MaterialText Colors.png")) {
+            MaterialTextPreview()
+        }
+    }
+}

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialTypographyTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialTypographyTests.kt
@@ -1,16 +1,9 @@
 package io.element.android.compound.screenshot
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.captureRoboImage
+import io.element.android.compound.previews.TypographyPreview
 import io.element.android.compound.screenshot.utils.screenshotFile
-import io.element.android.compound.theme.ElementTheme
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -23,34 +16,7 @@ class MaterialTypographyTests {
     @Config(sdk = [35], qualifiers = "h2048dp-xxhdpi")
     fun screenshots() {
         captureRoboImage(file = screenshotFile("Material Typography.png")) {
-            ElementTheme {
-                Surface {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        with(ElementTheme.materialTypography) {
-                            TypographyTokenPreview(displayLarge, "Display large")
-                            TypographyTokenPreview(displayMedium, "Display medium")
-                            TypographyTokenPreview(displaySmall, "Display small")
-                            TypographyTokenPreview(headlineLarge, "Headline large")
-                            TypographyTokenPreview(headlineMedium, "Headline medium")
-                            TypographyTokenPreview(headlineSmall, "Headline small")
-                            TypographyTokenPreview(titleLarge, "Title large")
-                            TypographyTokenPreview(titleMedium, "Title medium")
-                            TypographyTokenPreview(titleSmall, "Title small")
-                            TypographyTokenPreview(bodyLarge, "Body large")
-                            TypographyTokenPreview(bodyMedium, "Body medium")
-                            TypographyTokenPreview(bodySmall, "Body small")
-                            TypographyTokenPreview(labelLarge, "Label large")
-                            TypographyTokenPreview(labelMedium, "Label medium")
-                            TypographyTokenPreview(labelSmall, "Label small")
-                        }
-                    }
-                }
-            }
+            TypographyPreview()
         }
-    }
-
-    @Composable
-    private fun TypographyTokenPreview(style: TextStyle, text: String) {
-        Text(text = text, style = style)
     }
 }

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialTypographyTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialTypographyTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialYouThemeTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/MaterialYouThemeTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot
 
 import androidx.compose.foundation.layout.Arrangement

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/SemanticColorsTests.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/SemanticColorsTests.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot
 
 import androidx.compose.foundation.layout.Arrangement

--- a/compound/src/test/kotlin/io/element/android/compound/screenshot/utils/ScreenshotUtils.kt
+++ b/compound/src/test/kotlin/io/element/android/compound/screenshot/utils/ScreenshotUtils.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2023, 2025 New Vector Ltd.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+ * Please see LICENSE files in the repository root for full details.
+ */
+
 package io.element.android.compound.screenshot.utils
 
 import java.io.File


### PR DESCRIPTION
There were some mistakes when setting color for material theme. I tried to fix them all.

First commit is just moving code, second commit is fixing issue (hopefully), so it will be easier review commit per commit.

Splitting into 2 files has been done to be able to compare files and so spot diff between light and dark theme.

We will have to be careful when upgrading this library in EXA, and recorded screenshot should be reviewed carefully.

*EDIT* I have tested the effect on the application, and it seems that there is no regression. There are some diff in the screenshot, but nothing looks broken.