### PR TITLE
Migrate to Maven Central Portal

### DIFF
--- a/compound/build.gradle.kts
+++ b/compound/build.gradle.kts
@@ -90,7 +90,7 @@ configure<org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension> {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.S01)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
 
     coordinates("io.element.android", "compound-android", "25.4.4")


### PR DESCRIPTION
Change the `SonatypeHost` used to `CENTRAL_PORTAL`.

We also need to change this repo's credentials before merging.